### PR TITLE
Migrate to Sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Dviih/logger
 
-go 1.23
+go 1.24
 
 require (
 	github.com/Dviih/Array v1.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/Dviih/logger
 
 go 1.24
 
-require (
-	github.com/Dviih/Array v1.4.0 // indirect
-	github.com/Dviih/Channel v1.4.0 // indirect
-)
+require github.com/Dviih/sync v0.0.0-20250201154027-e7e915a5c8c2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/Dviih/Array v1.4.0 h1:/Clz+kWStqVDEFYFltCSqK+ER+0zCMXyq9pP5U/IMlw=
-github.com/Dviih/Array v1.4.0/go.mod h1:Y/Hz+OvZD67qAWUXvS5HrYhL9EUjUzilAn8s1NMLkls=
-github.com/Dviih/Channel v1.4.0 h1:5iEAL/2YUaE+sFcQQxjGyZSKrdAWqj9s1ENZnfM1ajg=
-github.com/Dviih/Channel v1.4.0/go.mod h1:IVlLDHydTUDHvLRzk9j7anL/T++wrM10mYXGZZgo0OI=
+github.com/Dviih/sync v0.0.0-20250201154027-e7e915a5c8c2 h1:fasMG+cL1Brikc6AqEEllYM0rfkC9k+y/2RTRpz3PNA=
+github.com/Dviih/sync v0.0.0-20250201154027-e7e915a5c8c2/go.mod h1:mj5YklTWxlUZkzCLpoLafQRvLHLdjg/vk7FcD5eS3xQ=

--- a/logger.go
+++ b/logger.go
@@ -22,10 +22,9 @@ package logger
 import (
 	"context"
 	"errors"
-	"github.com/Dviih/Array"
+	"github.com/Dviih/sync"
 	"io"
 	"log/slog"
-	"sync"
 	"time"
 )
 
@@ -35,7 +34,7 @@ type Logger struct {
 	time  string
 	level slog.Level
 
-	attributes *Array.Array[slog.Attr]
+	attributes *sync.Slice[slog.Attr]
 	group      []byte
 }
 
@@ -98,7 +97,7 @@ func (logger *Logger) Handle(ctx context.Context, record slog.Record) error {
 		return err
 	}
 
-	record.AddAttrs(logger.attributes.Array()...)
+	record.AddAttrs(logger.attributes.Slice()...)
 	record.Attrs(func(attribute slog.Attr) bool {
 		return logger.attrs("", attribute) == nil
 	})
@@ -113,8 +112,8 @@ func (logger *Logger) Handle(ctx context.Context, record slog.Record) error {
 func (logger *Logger) WithAttrs(attrs []slog.Attr) slog.Handler {
 	l := *logger
 
-	l.attributes = Array.New[slog.Attr]()
-	l.attributes.Append(append(logger.attributes.Array(), attrs...)...)
+	l.attributes = &sync.Slice[slog.Attr]{}
+	l.attributes.Append(append(logger.attributes.Slice(), attrs...)...)
 
 	return &l
 }
@@ -157,6 +156,6 @@ func New(writer io.Writer, time string, level slog.Level) *Logger {
 		writer:     writer,
 		time:       time,
 		level:      level,
-		attributes: Array.New[slog.Attr](),
+		attributes: &sync.Slice[slog.Attr]{},
 	}
 }


### PR DESCRIPTION
This pull request migrates [@Dviih/Array](https://github.com/Dviih/Array) and [@Dviih/Channel](https://github.com/Dviih/Channel) to [@Dviih/sync](https://github.com/Dviih/sync).
The `sync` libraries provides a better handler for slices as `sync.Slice`.