### PR TITLE
Patch unexported fields

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -215,6 +215,7 @@ func (logger *Logger) attr2(s string, attribute slog.Attr) error {
 				continue
 			}
 
+			if err := logger.attrs(prefix(s, attribute.Key), slog.Any(ft.Name, value.Field(i).Interface())); err != nil {
 				return err
 			}
 		}

--- a/attr.go
+++ b/attr.go
@@ -1,6 +1,6 @@
 /*
  *     A colored handler for slog.
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published
@@ -209,7 +209,7 @@ func (logger *Logger) attr2(s string, attribute slog.Attr) error {
 		}
 	case reflect.Struct:
 		for i := 0; i < value.NumField(); i++ {
-			if err := logger.attrs(prefix(s, attribute.Key), slog.Any(value.Type().Field(i).Name, value.Field(i).Interface())); err != nil {
+			ft := value.Type().Field(i)
 				return err
 			}
 		}

--- a/attr.go
+++ b/attr.go
@@ -210,6 +210,11 @@ func (logger *Logger) attr2(s string, attribute slog.Attr) error {
 	case reflect.Struct:
 		for i := 0; i < value.NumField(); i++ {
 			ft := value.Type().Field(i)
+
+			if !ft.IsExported() {
+				continue
+			}
+
 				return err
 			}
 		}

--- a/logger.go
+++ b/logger.go
@@ -140,7 +140,7 @@ func (logger *Logger) write(v interface{}) error {
 	case string:
 		data = []byte(v)
 	default:
-		panic("not string or byte(s)")
+		return ErrorInvalidInput
 	}
 
 	n, err := logger.writer.Write(data)

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,6 @@
 /*
  *     A colored handler for slog.
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published
@@ -53,6 +53,9 @@ var (
 
 	_true  = []byte("\u001B[0;32mtrue")
 	_false = []byte("\u001B[0;31mfalse")
+
+	ErrorWhileWriting = errors.New("error while writing to writer")
+	ErrorInvalidInput = errors.New("invalid input, input must be either string or byte(s)")
 )
 
 func (logger *Logger) Enabled(ctx context.Context, level slog.Level) bool {

--- a/logger.go
+++ b/logger.go
@@ -149,7 +149,7 @@ func (logger *Logger) write(v interface{}) error {
 	}
 
 	if n != len(data) {
-		return errors.New("wrote less")
+		return ErrorWhileWriting
 	}
 
 	return nil

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,6 +1,6 @@
 /*
  *     A colored handler for slog.
- *     Copyright (C) 2024  Dviih
+ *     Copyright (C) 2025  Dviih
  *
  *     This program is free software: you can redistribute it and/or modify
  *     it under the terms of the GNU Affero General Public License as published
@@ -78,7 +78,8 @@ func TestLoggerMap(t *testing.T) {
 
 func TestLoggerStruct(t *testing.T) {
 	test.Warn("a struct", slog.Any("struct", struct {
-		FieldOne string
-		FieldTwo int
-	}{"value1", 24}))
+		FieldOne   string
+		FieldTwo   int
+		unexported int
+	}{"value1", 24, 13}))
 }


### PR DESCRIPTION
This pull request patches when trying to get `Interface` from unexported fields of structures, also adds to struct's test an unexported field to ensure it working.
Also includes new errors and removes panic from `write`.